### PR TITLE
Respect Category Top Navigation Max Depth setting

### DIFF
--- a/app/code/Magento/Catalog/Model/ResourceModel/Category/Collection.php
+++ b/app/code/Magento/Catalog/Model/ResourceModel/Category/Collection.php
@@ -6,12 +6,14 @@
 namespace Magento\Catalog\Model\ResourceModel\Category;
 
 use Magento\CatalogUrlRewrite\Model\CategoryUrlRewriteGenerator;
+use Magento\Store\Model\ScopeInterface;
 
 /**
  * Category resource collection
  *
  * @api
  * @author      Magento Core Team <core@magentocommerce.com>
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @since 100.0.2
  */
 class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\AbstractCollection
@@ -57,6 +59,60 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
      * @var boolean
      */
     protected $_loadWithProductCount = false;
+
+    /**
+     * Core store config
+     *
+     * @var \Magento\Framework\App\Config\ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    /**
+     * Constructor
+     * @param \Magento\Framework\Data\Collection\EntityFactory $entityFactory
+     * @param \Psr\Log\LoggerInterface $logger
+     * @param \Magento\Framework\Data\Collection\Db\FetchStrategyInterface $fetchStrategy
+     * @param \Magento\Framework\Event\ManagerInterface $eventManager
+     * @param \Magento\Eav\Model\Config $eavConfig
+     * @param \Magento\Framework\App\ResourceConnection $resource
+     * @param \Magento\Eav\Model\EntityFactory $eavEntityFactory
+     * @param \Magento\Eav\Model\ResourceModel\Helper $resourceHelper
+     * @param \Magento\Framework\Validator\UniversalFactory $universalFactory
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+     * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+     * @param \Magento\Framework\DB\Adapter\AdapterInterface|null $connection
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     */
+    public function __construct(
+        \Magento\Framework\Data\Collection\EntityFactory $entityFactory,
+        \Psr\Log\LoggerInterface $logger,
+        \Magento\Framework\Data\Collection\Db\FetchStrategyInterface $fetchStrategy,
+        \Magento\Framework\Event\ManagerInterface $eventManager,
+        \Magento\Eav\Model\Config $eavConfig,
+        \Magento\Framework\App\ResourceConnection $resource,
+        \Magento\Eav\Model\EntityFactory $eavEntityFactory,
+        \Magento\Eav\Model\ResourceModel\Helper $resourceHelper,
+        \Magento\Framework\Validator\UniversalFactory $universalFactory,
+        \Magento\Store\Model\StoreManagerInterface $storeManager,
+        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
+        \Magento\Framework\DB\Adapter\AdapterInterface $connection = null
+    ) {
+        parent::__construct(
+            $entityFactory,
+            $logger,
+            $fetchStrategy,
+            $eventManager,
+            $eavConfig,
+            $resource,
+            $eavEntityFactory,
+            $resourceHelper,
+            $universalFactory,
+            $storeManager,
+            $connection
+        );
+        $this->scopeConfig = $scopeConfig;
+    }
 
     /**
      * Init collection and determine table names
@@ -401,6 +457,23 @@ class Collection extends \Magento\Catalog\Model\ResourceModel\Collection\Abstrac
     {
         $this->addFieldToFilter('path', ['neq' => '1']);
         $this->addLevelFilter(1);
+        return $this;
+    }
+
+    /**
+     * Add navigation max depth filter
+     *
+     * @return $this
+     */
+    public function addNavigationMaxDepthFilter()
+    {
+        $navigationMaxDepth = (int)$this->scopeConfig->getValue(
+            'catalog/navigation/max_depth',
+            ScopeInterface::SCOPE_STORE
+        );
+        if ($navigationMaxDepth > 0) {
+            $this->addLevelFilter($navigationMaxDepth);
+        }
         return $this;
     }
 

--- a/app/code/Magento/Catalog/Plugin/Block/Topmenu.php
+++ b/app/code/Magento/Catalog/Plugin/Block/Topmenu.php
@@ -183,6 +183,7 @@ class Topmenu
         $collection->addFieldToFilter('path', ['like' => '1/' . $rootId . '/%']); //load only from store root
         $collection->addAttributeToFilter('include_in_menu', 1);
         $collection->addIsActiveFilter();
+        $collection->addNavigationMaxDepthFilter();
         $collection->addUrlRewriteToResult();
         $collection->addOrder('level', Collection::SORT_ORDER_ASC);
         $collection->addOrder('position', Collection::SORT_ORDER_ASC);


### PR DESCRIPTION
### Description
The setting `Stores > Configuration > Catalog > Catalog > Category Top Navigation > Maximal Depth` was actually never being used to limit the top menu maximum depth.

Now the setting will be used as a condition for the category collection when it is fetched.

### Fixed Issues
1. magento/magento2#7543: Category Top Navigation / Maximal Depth configuration not working

### Manual testing scenarios
1. Change the setting in the backend
2. Refresh the invalidated cache
3. See that the setting actually is being used

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
