### PR TITLE
Add the domReady! statement for editing the cart product on the PDP

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/js/view/configure/product-customer-data.js
+++ b/app/code/Magento/Checkout/view/frontend/web/js/view/configure/product-customer-data.js
@@ -1,6 +1,7 @@
 require([
     'jquery',
-    'Magento_Customer/js/customer-data'
+    'Magento_Customer/js/customer-data',
+    'domReady!'
 ], function ($, customerData) {
     'use strict';
 


### PR DESCRIPTION
### Description
When you are on the cart page and click on the 'edit' link for a product you are being redirected to the PDP and the current amount for that product that is in the cart should be filled in the amount field on the PDP.

In production mode when the settings minify and merge the javascript files in `Stores > Configuration > Advanced > Developer` are enabled the jquery selector sometimes (depending on the amount of javascript files) returns no values because the DOM is not ready when the script is executed.

By adding the domReady! statement in the require part we are sure that when the jQuery selector is being filled the DOM is ready.

This issue could not be reproduced on a clean magento 2.2 installation, but in a project where significantly more (external) modules (and therefore more javascript files) are included the issue occurred. 

### Manual testing scenarios
1. Go to a PDP
2. Add a product to the cart
3. Go to the cart page (view and edit cart from the minicart)
4. Click the edit button for the product in the cart
5. See that the amount that you have in your cart for the product is being filled in the amount field on the PDP.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
