### PR TITLE
Update the processing of items for the top menu

### DIFF
--- a/app/code/Magento/Theme/Block/Html/Topmenu.php
+++ b/app/code/Magento/Theme/Block/Html/Topmenu.php
@@ -213,6 +213,13 @@ class Topmenu extends Template implements IdentityInterface
         $parentLevel = $menuTree->getLevel();
         $childLevel = $parentLevel === null ? 0 : $parentLevel + 1;
 
+        /** @var \Magento\Framework\Data\Tree\Node $child */
+        foreach ($children as $key => $child) {
+            if ($childLevel === 0 && $child->getData('is_parent_active') === false) {
+                unset($children[$key]);
+            }
+        }
+
         $counter = 1;
         $itemPosition = 1;
         $childrenCount = $children->count();
@@ -220,11 +227,7 @@ class Topmenu extends Template implements IdentityInterface
         $parentPositionClass = $menuTree->getPositionClass();
         $itemPositionClassPrefix = $parentPositionClass ? $parentPositionClass . '-' : 'nav-';
 
-        /** @var \Magento\Framework\Data\Tree\Node $child */
         foreach ($children as $child) {
-            if ($childLevel === 0 && $child->getData('is_parent_active') === false) {
-                continue;
-            }
             $child->setLevel($childLevel);
             $child->setIsFirst($counter == 1);
             $child->setIsLast($counter == $childrenCount);


### PR DESCRIPTION
### Description
The counter in the foreach loop was not being calculated correctly. This resolved in the 'last' css class not being set on the output when one or more parent items are not active.

With this commit the items will be filtered first before they are being processed for the html output.

### Fixed Issues (if relevant)
1. magento/magento2#13266: Topmenu 'last' class not being set if the a parent is inactive

### Manual testing scenarios
1. Do a clean install of Magento 2.2 with sample data
2. Set a level 1 category (e.g. Gear or Gift Cards) inactive
3. Refresh the appropriate cache items
4. Inspect the menu and see there is a class **last** on the last active top menu item

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
