### PR TITLE
Update the processing of items for the top menu

### DIFF
--- a/app/code/Magento/Theme/Block/Html/Topmenu.php
+++ b/app/code/Magento/Theme/Block/Html/Topmenu.php
@@ -30,7 +30,7 @@ class Topmenu extends Template implements IdentityInterface
     /**
      * Top menu data tree
      *
-     * @var \Magento\Framework\Data\Tree\Node
+     * @var Node
      */
     protected $_menu;
 
@@ -165,7 +165,7 @@ class Topmenu extends Template implements IdentityInterface
     /**
      * Add sub menu HTML code for current menu item
      *
-     * @param \Magento\Framework\Data\Tree\Node $child
+     * @param Node $child
      * @param string $childLevel
      * @param string $childrenWrapClass
      * @param int $limit
@@ -193,7 +193,7 @@ class Topmenu extends Template implements IdentityInterface
     /**
      * Recursively generates top menu html from data that is specified in $menuTree
      *
-     * @param \Magento\Framework\Data\Tree\Node $menuTree
+     * @param Node $menuTree
      * @param string $childrenWrapClass
      * @param int $limit
      * @param array $colBrakes
@@ -203,7 +203,7 @@ class Topmenu extends Template implements IdentityInterface
      * @SuppressWarnings(PHPMD.NPathComplexity)
      */
     protected function _getHtml(
-        \Magento\Framework\Data\Tree\Node $menuTree,
+        Node $menuTree,
         $childrenWrapClass,
         $limit,
         $colBrakes = []
@@ -225,7 +225,7 @@ class Topmenu extends Template implements IdentityInterface
         $parentPositionClass = $menuTree->getPositionClass();
         $itemPositionClassPrefix = $parentPositionClass ? $parentPositionClass . '-' : 'nav-';
 
-        /** @var \Magento\Framework\Data\Tree\Node $child */
+        /** @var Node $child */
         foreach ($children as $child) {
             $child->setLevel($childLevel);
             $child->setIsFirst($counter == 1);
@@ -273,10 +273,10 @@ class Topmenu extends Template implements IdentityInterface
     /**
      * Generates string with all attributes that should be present in menu item element
      *
-     * @param \Magento\Framework\Data\Tree\Node $item
+     * @param Node $item
      * @return string
      */
-    protected function _getRenderedMenuItemAttributes(\Magento\Framework\Data\Tree\Node $item)
+    protected function _getRenderedMenuItemAttributes(Node $item)
     {
         $html = '';
         $attributes = $this->_getMenuItemAttributes($item);
@@ -289,10 +289,10 @@ class Topmenu extends Template implements IdentityInterface
     /**
      * Returns array of menu item's attributes
      *
-     * @param \Magento\Framework\Data\Tree\Node $item
+     * @param Node $item
      * @return array
      */
-    protected function _getMenuItemAttributes(\Magento\Framework\Data\Tree\Node $item)
+    protected function _getMenuItemAttributes(Node $item)
     {
         $menuItemClasses = $this->_getMenuItemClasses($item);
         return ['class' => implode(' ', $menuItemClasses)];
@@ -301,10 +301,10 @@ class Topmenu extends Template implements IdentityInterface
     /**
      * Returns array of menu item's classes
      *
-     * @param \Magento\Framework\Data\Tree\Node $item
+     * @param Node $item
      * @return array
      */
-    protected function _getMenuItemClasses(\Magento\Framework\Data\Tree\Node $item)
+    protected function _getMenuItemClasses(Node $item)
     {
         $classes = [];
 
@@ -386,7 +386,7 @@ class Topmenu extends Template implements IdentityInterface
     /**
      * Get menu object.
      *
-     * Creates \Magento\Framework\Data\Tree\Node root node object.
+     * Creates Node root node object.
      * The creation logic was moved from class constructor into separate method.
      *
      * @return Node

--- a/app/code/Magento/Theme/Block/Html/Topmenu.php
+++ b/app/code/Magento/Theme/Block/Html/Topmenu.php
@@ -6,6 +6,7 @@
 namespace Magento\Theme\Block\Html;
 
 use Magento\Framework\Data\Tree\Node;
+use Magento\Framework\Data\Tree\Node\Collection;
 use Magento\Framework\Data\Tree\NodeFactory;
 use Magento\Framework\Data\TreeFactory;
 use Magento\Framework\DataObject\IdentityInterface;
@@ -213,11 +214,8 @@ class Topmenu extends Template implements IdentityInterface
         $parentLevel = $menuTree->getLevel();
         $childLevel = $parentLevel === null ? 0 : $parentLevel + 1;
 
-        /** @var \Magento\Framework\Data\Tree\Node $child */
-        foreach ($children as $key => $child) {
-            if ($childLevel === 0 && $child->getData('is_parent_active') === false) {
-                unset($children[$key]);
-            }
+        if ($childLevel === 0) {
+            $this->removeOrphans($children);
         }
 
         $counter = 1;
@@ -406,5 +404,21 @@ class Topmenu extends Template implements IdentityInterface
             );
         }
         return $this->_menu;
+    }
+
+    /**
+     * Remove children from collection when the parent is not active
+     *
+     * @param Collection $children
+     * @return void
+     */
+    private function removeOrphans(Collection $children)
+    {
+        /** @var Node $child */
+        foreach ($children as $child) {
+            if ($child->getData('is_parent_active') === false) {
+                $children->delete($child);
+            }
+        }
     }
 }

--- a/app/code/Magento/Theme/Block/Html/Topmenu.php
+++ b/app/code/Magento/Theme/Block/Html/Topmenu.php
@@ -213,6 +213,13 @@ class Topmenu extends Template implements IdentityInterface
         $parentLevel = $menuTree->getLevel();
         $childLevel = $parentLevel === null ? 0 : $parentLevel + 1;
 
+        /** @var \Magento\Framework\Data\Tree\Node $child */
+        foreach ($children as $key => $child) {
+            if ($childLevel === 0 && $child->getData('is_parent_active') === false) {
+                unset($children[$key]);
+            }
+        }
+
         $counter = 1;
         $itemPosition = 1;
         $childrenCount = $children->count();
@@ -222,9 +229,6 @@ class Topmenu extends Template implements IdentityInterface
 
         /** @var \Magento\Framework\Data\Tree\Node $child */
         foreach ($children as $child) {
-            if ($childLevel === 0 && $child->getData('is_parent_active') === false) {
-                continue;
-            }
             $child->setLevel($childLevel);
             $child->setIsFirst($counter == 1);
             $child->setIsLast($counter == $childrenCount);


### PR DESCRIPTION
### Description
The counter in the foreach loop was not being calculated correctly. This resolved in the 'last' css class not being set on the output when one or more parent items are not active.

With this commit the items will be filtered first before they are being processed for the html output.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#13266: Topmenu 'last' class not being set if the a parent is inactive

### Manual testing scenarios
1. Do a clean install of Magento 2.2 with sample data
2. Set a level 1 category (e.g. Gear or Gift Cards) inactive
3. Refresh the appropriate cache
4. Inspect the menu and see there is a class **last** on the last active top menu item

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
