### PR TITLE
Remove ui-state-active from siblings of the expanded menu item

### DIFF
--- a/lib/web/mage/menu.js
+++ b/lib/web/mage/menu.js
@@ -626,6 +626,9 @@ define([
                     return;
                 }
 
+                // remove the active state class from the siblings
+                this.active.siblings().children('.ui-state-active').removeClass('ui-state-active');
+
                 this._open(newItem.parent());
 
                 // Delay so Firefox will not hide activedescendant change in expanding submenu from AT


### PR DESCRIPTION
### Description
Previously when a menu item was expanded the class `ui-state-active` was
not removed from the previous expanded menu item. This resulted in two
(or more if you expanded more) menu items with this class.

### Fixed Issues (if relevant)
1. magento/magento2#13327 Menu ui-state-active not removed from previous opened menu item

### Manual testing scenarios
1. In your browser switch to mobile view so you have the mobile menu
2. Open the menu
3. Expand the menu item **Women**
4. Now expand the menu item **Men**
5. See that the `ui-state-active` class is removed from **Women**

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)
