### PR TITLE
Make the lib-icon-font to have as a parameter the font-weight

### DIFF
--- a/lib/web/css/source/lib/_icons.less
+++ b/lib/web/css/source/lib/_icons.less
@@ -24,7 +24,7 @@
     @_icon-font-position: @icon-font__position,
     @_icon-font-text-hide: @icon-font__text-hide,
     @_icon-font-display: @icon-font__display,
-    @_icon-font-weight: @icon-font__weight
+    @_icon-font-font-weight: @icon-font__font-weight
 ) when (@_icon-font-position = before) {
     ._lib-icon-text-hide(@_icon-font-text-hide);
     .lib-css(display, @_icon-font-display);
@@ -39,7 +39,7 @@
             @_icon-font-color,
             @_icon-font-margin,
             @_icon-font-vertical-align,
-            @_icon-font-weight
+            @_icon-font-font-weight
         );
     }
 
@@ -69,7 +69,7 @@
     @_icon-font-position: @icon-font__position,
     @_icon-font-text-hide: @icon-font__text-hide,
     @_icon-font-display: @icon-font__display,
-    @_icon-font-weight: @icon-font__font-weight
+    @_icon-font-font-weight: @icon-font__font-weight
 ) when (@_icon-font-position = after) {
     ._lib-icon-text-hide(@_icon-font-text-hide);
     .lib-css(display, @_icon-font-display);
@@ -84,7 +84,7 @@
             @_icon-font-color,
             @_icon-font-margin,
             @_icon-font-vertical-align,
-            @_icon-font-weight
+            @_icon-font-font-weight
         );
     }
 
@@ -346,7 +346,7 @@
     @_icon-font-color,
     @_icon-font-margin,
     @_icon-font-vertical-align,
-    @_icon-font-weight
+    @_icon-font-font-weight
 ) {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
@@ -356,7 +356,7 @@
     .lib-css(font-family, @_icon-font);
     .lib-css(margin, @_icon-font-margin);
     .lib-css(vertical-align, @_icon-font-vertical-align);
-    .lib-css(font-weight, @_icon-font-weight);
+    .lib-css(font-weight, @_icon-font-font-weight);
     display: inline-block;
     overflow: hidden;
     speak: none;

--- a/lib/web/css/source/lib/_icons.less
+++ b/lib/web/css/source/lib/_icons.less
@@ -32,14 +32,14 @@
 
     &:before {
         ._lib-icon-font(
-                @_icon-font-content,
-                @_icon-font,
-                @_icon-font-size,
-                @_icon-font-line-height,
-                @_icon-font-color,
-                @_icon-font-margin,
-                @_icon-font-vertical-align,
-                @_icon-font-weight
+            @_icon-font-content,
+            @_icon-font,
+            @_icon-font-size,
+            @_icon-font-line-height,
+            @_icon-font-color,
+            @_icon-font-margin,
+            @_icon-font-vertical-align,
+            @_icon-font-weight
         );
     }
 
@@ -69,7 +69,7 @@
     @_icon-font-position: @icon-font__position,
     @_icon-font-text-hide: @icon-font__text-hide,
     @_icon-font-display: @icon-font__display,
-    @_icon-font-weight: @icon-font__weight
+    @_icon-font-weight: @icon-font__font-weight
 ) when (@_icon-font-position = after) {
     ._lib-icon-text-hide(@_icon-font-text-hide);
     .lib-css(display, @_icon-font-display);
@@ -77,14 +77,14 @@
 
     &:after {
         ._lib-icon-font(
-                @_icon-font-content,
-                @_icon-font,
-                @_icon-font-size,
-                @_icon-font-line-height,
-                @_icon-font-color,
-                @_icon-font-margin,
-                @_icon-font-vertical-align,
-                @_icon-font-weight
+            @_icon-font-content,
+            @_icon-font,
+            @_icon-font-size,
+            @_icon-font-line-height,
+            @_icon-font-color,
+            @_icon-font-margin,
+            @_icon-font-vertical-align,
+            @_icon-font-weight
         );
     }
 
@@ -159,13 +159,13 @@
 
     &:before {
         ._lib-icon-image(
-                @_icon-image,
-                @_icon-image-width,
-                @_icon-image-height,
-                @_icon-image-margin,
-                @_icon-image-vertical-align,
-                @_icon-image-position-x,
-                @_icon-image-position-y
+            @_icon-image,
+            @_icon-image-width,
+            @_icon-image-height,
+            @_icon-image-margin,
+            @_icon-image-vertical-align,
+            @_icon-image-position-x,
+            @_icon-image-position-y
         );
         .lib-css(margin, @_icon-image-margin);
     }
@@ -187,13 +187,13 @@
 
     &:after {
         ._lib-icon-image(
-                @_icon-image,
-                @_icon-image-width,
-                @_icon-image-height,
-                @_icon-image-margin,
-                @_icon-image-vertical-align,
-                @_icon-image-position-x,
-                @_icon-image-position-y
+            @_icon-image,
+            @_icon-image-width,
+            @_icon-image-height,
+            @_icon-image-margin,
+            @_icon-image-vertical-align,
+            @_icon-image-position-x,
+            @_icon-image-position-y
         );
         .lib-css(margin, @_icon-image-margin);
     }
@@ -206,8 +206,8 @@
 ) when (@_icon-image-position = before) {
     &:before {
         ._lib-icon-image-position(
-                @_icon-image-position-x,
-                @_icon-image-position-y
+            @_icon-image-position-x,
+            @_icon-image-position-y
         );
     }
 }
@@ -219,8 +219,8 @@
 ) when (@_icon-image-position = after) {
     &:after {
         ._lib-icon-image-position(
-                @_icon-image-position-x,
-                @_icon-image-position-y
+            @_icon-image-position-x,
+            @_icon-image-position-y
         );
     }
 }
@@ -233,9 +233,9 @@
 ) when (@_icon-sprite-position = before) {
     &:before {
         ._lib-icon-sprite-position(
-                @_icon-sprite-position-x,
-                @_icon-sprite-position-y,
-                @_icon-sprite-grid
+            @_icon-sprite-position-x,
+            @_icon-sprite-position-y,
+            @_icon-sprite-grid
         );
     }
 }
@@ -248,9 +248,9 @@
 ) when (@_icon-sprite-position = after) {
     &:after {
         ._lib-icon-sprite-position(
-                @_icon-sprite-position-x,
-                @_icon-sprite-position-y,
-                @_icon-sprite-grid
+            @_icon-sprite-position-x,
+            @_icon-sprite-position-y,
+            @_icon-sprite-grid
         );
     }
 }
@@ -307,8 +307,8 @@
     .lib-css(margin, @_icon-image-margin);
     .lib-css(vertical-align, @_icon-image-vertical-align);
     ._lib-icon-image-size(
-            @_icon-image-width,
-            @_icon-image-height
+        @_icon-image-width,
+        @_icon-image-height
     );
     background-repeat: no-repeat;
     content: '';

--- a/lib/web/css/source/lib/_icons.less
+++ b/lib/web/css/source/lib/_icons.less
@@ -23,7 +23,8 @@
     @_icon-font-vertical-align: @icon-font__vertical-align,
     @_icon-font-position: @icon-font__position,
     @_icon-font-text-hide: @icon-font__text-hide,
-    @_icon-font-display: @icon-font__display
+    @_icon-font-display: @icon-font__display,
+    @_icon-font-weight: @icon-font__weight
 ) when (@_icon-font-position = before) {
     ._lib-icon-text-hide(@_icon-font-text-hide);
     .lib-css(display, @_icon-font-display);
@@ -31,13 +32,14 @@
 
     &:before {
         ._lib-icon-font(
-            @_icon-font-content,
-            @_icon-font,
-            @_icon-font-size,
-            @_icon-font-line-height,
-            @_icon-font-color,
-            @_icon-font-margin,
-            @_icon-font-vertical-align
+                @_icon-font-content,
+                @_icon-font,
+                @_icon-font-size,
+                @_icon-font-line-height,
+                @_icon-font-color,
+                @_icon-font-margin,
+                @_icon-font-vertical-align,
+                @_icon-font-weight
         );
     }
 
@@ -66,7 +68,8 @@
     @_icon-font-vertical-align: @icon-font__vertical-align,
     @_icon-font-position: @icon-font__position,
     @_icon-font-text-hide: @icon-font__text-hide,
-    @_icon-font-display: @icon-font__display
+    @_icon-font-display: @icon-font__display,
+    @_icon-font-weight: @icon-font__weight
 ) when (@_icon-font-position = after) {
     ._lib-icon-text-hide(@_icon-font-text-hide);
     .lib-css(display, @_icon-font-display);
@@ -74,13 +77,14 @@
 
     &:after {
         ._lib-icon-font(
-            @_icon-font-content,
-            @_icon-font,
-            @_icon-font-size,
-            @_icon-font-line-height,
-            @_icon-font-color,
-            @_icon-font-margin,
-            @_icon-font-vertical-align
+                @_icon-font-content,
+                @_icon-font,
+                @_icon-font-size,
+                @_icon-font-line-height,
+                @_icon-font-color,
+                @_icon-font-margin,
+                @_icon-font-vertical-align,
+                @_icon-font-weight
         );
     }
 
@@ -155,13 +159,13 @@
 
     &:before {
         ._lib-icon-image(
-            @_icon-image,
-            @_icon-image-width,
-            @_icon-image-height,
-            @_icon-image-margin,
-            @_icon-image-vertical-align,
-            @_icon-image-position-x,
-            @_icon-image-position-y
+                @_icon-image,
+                @_icon-image-width,
+                @_icon-image-height,
+                @_icon-image-margin,
+                @_icon-image-vertical-align,
+                @_icon-image-position-x,
+                @_icon-image-position-y
         );
         .lib-css(margin, @_icon-image-margin);
     }
@@ -183,13 +187,13 @@
 
     &:after {
         ._lib-icon-image(
-            @_icon-image,
-            @_icon-image-width,
-            @_icon-image-height,
-            @_icon-image-margin,
-            @_icon-image-vertical-align,
-            @_icon-image-position-x,
-            @_icon-image-position-y
+                @_icon-image,
+                @_icon-image-width,
+                @_icon-image-height,
+                @_icon-image-margin,
+                @_icon-image-vertical-align,
+                @_icon-image-position-x,
+                @_icon-image-position-y
         );
         .lib-css(margin, @_icon-image-margin);
     }
@@ -202,8 +206,8 @@
 ) when (@_icon-image-position = before) {
     &:before {
         ._lib-icon-image-position(
-            @_icon-image-position-x,
-            @_icon-image-position-y
+                @_icon-image-position-x,
+                @_icon-image-position-y
         );
     }
 }
@@ -215,8 +219,8 @@
 ) when (@_icon-image-position = after) {
     &:after {
         ._lib-icon-image-position(
-            @_icon-image-position-x,
-            @_icon-image-position-y
+                @_icon-image-position-x,
+                @_icon-image-position-y
         );
     }
 }
@@ -229,9 +233,9 @@
 ) when (@_icon-sprite-position = before) {
     &:before {
         ._lib-icon-sprite-position(
-            @_icon-sprite-position-x,
-            @_icon-sprite-position-y,
-            @_icon-sprite-grid
+                @_icon-sprite-position-x,
+                @_icon-sprite-position-y,
+                @_icon-sprite-grid
         );
     }
 }
@@ -244,9 +248,9 @@
 ) when (@_icon-sprite-position = after) {
     &:after {
         ._lib-icon-sprite-position(
-            @_icon-sprite-position-x,
-            @_icon-sprite-position-y,
-            @_icon-sprite-grid
+                @_icon-sprite-position-x,
+                @_icon-sprite-position-y,
+                @_icon-sprite-grid
         );
     }
 }
@@ -303,8 +307,8 @@
     .lib-css(margin, @_icon-image-margin);
     .lib-css(vertical-align, @_icon-image-vertical-align);
     ._lib-icon-image-size(
-        @_icon-image-width,
-        @_icon-image-height
+            @_icon-image-width,
+            @_icon-image-height
     );
     background-repeat: no-repeat;
     content: '';
@@ -341,7 +345,8 @@
     @_icon-font-line-height,
     @_icon-font-color,
     @_icon-font-margin,
-    @_icon-font-vertical-align
+    @_icon-font-vertical-align,
+    @_icon-font-weight
 ) {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
@@ -351,8 +356,8 @@
     .lib-css(font-family, @_icon-font);
     .lib-css(margin, @_icon-font-margin);
     .lib-css(vertical-align, @_icon-font-vertical-align);
+    .lib-css(font-weight, @_icon-font-weight);
     display: inline-block;
-    font-weight: normal;
     overflow: hidden;
     speak: none;
     text-align: center;

--- a/lib/web/css/source/lib/_messages.less
+++ b/lib/web/css/source/lib/_messages.less
@@ -172,7 +172,7 @@ and not (@_message-border-style = false) {
                 @_icon-font-color: @_message-icon-color,
                 @_icon-font-margin: -@message-icon__font-size/2 0 0,
                 @_icon-font-vertical-align: @icon-font__vertical-align,
-                @_icon-font-weight: @icon-font__weight
+                @_icon-font-font-weight: @icon-font__font-weight
             );
             .lib-css(bottom, @_message-icon-bottom);
             .lib-css(left, @_message-icon-left);
@@ -270,7 +270,7 @@ and not (@_message-border-style = false) {
             @_icon-font-color: @_message-icon-color,
             @_icon-font-margin: -@message-icon__font-size/2 0 0,
             @_icon-font-vertical-align: @icon-font__vertical-align,
-            @_icon-font-weight: @icon-font__weight
+            @_icon-font-font-weight: @icon-font__font-weight
         );
         .lib-css(bottom, @_message-icon-bottom);
         .lib-css(left, @_message-icon-left);

--- a/lib/web/css/source/lib/_messages.less
+++ b/lib/web/css/source/lib/_messages.less
@@ -95,14 +95,14 @@ and not (@_message-border-style = false) {
     @_message-icon-bottom: "message-@{_message-type}-icon__bottom";
     @_message-icon-left: "message-@{_message-type}-icon__left";
     ._lib-message-icon-lateral(
-        @_message-icon-position,
-        @@_message-icon,
-        @@_message-icon-color,
-        @@_message-icon-background,
-        @@_message-icon-top,
-        @@_message-icon-left,
-        @@_message-icon-bottom,
-        @@_message-icon-right
+            @_message-icon-position,
+            @@_message-icon,
+            @@_message-icon-color,
+            @@_message-icon-background,
+            @@_message-icon-top,
+            @@_message-icon-left,
+            @@_message-icon-bottom,
+            @@_message-icon-right
     );
 }
 
@@ -117,13 +117,13 @@ and not (@_message-border-style = false) {
     @_message-icon-bottom: "message-@{_message-type}-icon__bottom";
     @_message-icon-left: "message-@{_message-type}-icon__left";
     ._lib-message-icon-inner(
-        @@_message-icon,
-        @@_message-icon-color,
-        @@_message-icon-background,
-        @@_message-icon-top,
-        @@_message-icon-left,
-        @@_message-icon-bottom,
-        @@_message-icon-right
+            @@_message-icon,
+            @@_message-icon-color,
+            @@_message-icon-background,
+            @@_message-icon-top,
+            @@_message-icon-left,
+            @@_message-icon-bottom,
+            @@_message-icon-right
     );
 }
 
@@ -171,7 +171,8 @@ and not (@_message-border-style = false) {
                 @_icon-font-line-height: @message-icon__font-line-height,
                 @_icon-font-color: @_message-icon-color,
                 @_icon-font-margin: -@message-icon__font-size/2 0 0,
-                @_icon-font-vertical-align: @icon-font__vertical-align
+                @_icon-font-vertical-align: @icon-font__vertical-align,
+                @_icon-font-weight: @icon-font__weight
             );
             .lib-css(bottom, @_message-icon-bottom);
             .lib-css(left, @_message-icon-left);
@@ -184,8 +185,8 @@ and not (@_message-border-style = false) {
     }
 
     ._lib-message-icon-lateral-position(
-        @_message-icon-position,
-        @_message-icon-background
+            @_message-icon-position,
+            @_message-icon-background
     );
 }
 
@@ -268,7 +269,8 @@ and not (@_message-border-style = false) {
             @_icon-font-line-height: @message-icon__font-line-height,
             @_icon-font-color: @_message-icon-color,
             @_icon-font-margin: -@message-icon__font-size/2 0 0,
-            @_icon-font-vertical-align: @icon-font__vertical-align
+            @_icon-font-vertical-align: @icon-font__vertical-align,
+            @_icon-font-weight: @icon-font__weight
         );
         .lib-css(bottom, @_message-icon-bottom);
         .lib-css(left, @_message-icon-left);

--- a/lib/web/css/source/lib/_messages.less
+++ b/lib/web/css/source/lib/_messages.less
@@ -95,14 +95,14 @@ and not (@_message-border-style = false) {
     @_message-icon-bottom: "message-@{_message-type}-icon__bottom";
     @_message-icon-left: "message-@{_message-type}-icon__left";
     ._lib-message-icon-lateral(
-            @_message-icon-position,
-            @@_message-icon,
-            @@_message-icon-color,
-            @@_message-icon-background,
-            @@_message-icon-top,
-            @@_message-icon-left,
-            @@_message-icon-bottom,
-            @@_message-icon-right
+        @_message-icon-position,
+        @@_message-icon,
+        @@_message-icon-color,
+        @@_message-icon-background,
+        @@_message-icon-top,
+        @@_message-icon-left,
+        @@_message-icon-bottom,
+        @@_message-icon-right
     );
 }
 
@@ -117,13 +117,13 @@ and not (@_message-border-style = false) {
     @_message-icon-bottom: "message-@{_message-type}-icon__bottom";
     @_message-icon-left: "message-@{_message-type}-icon__left";
     ._lib-message-icon-inner(
-            @@_message-icon,
-            @@_message-icon-color,
-            @@_message-icon-background,
-            @@_message-icon-top,
-            @@_message-icon-left,
-            @@_message-icon-bottom,
-            @@_message-icon-right
+        @@_message-icon,
+        @@_message-icon-color,
+        @@_message-icon-background,
+        @@_message-icon-top,
+        @@_message-icon-left,
+        @@_message-icon-bottom,
+        @@_message-icon-right
     );
 }
 
@@ -185,8 +185,8 @@ and not (@_message-border-style = false) {
     }
 
     ._lib-message-icon-lateral-position(
-            @_message-icon-position,
-            @_message-icon-background
+        @_message-icon-position,
+        @_message-icon-background
     );
 }
 

--- a/lib/web/css/source/lib/variables/_icons.less
+++ b/lib/web/css/source/lib/variables/_icons.less
@@ -32,7 +32,7 @@
 @icon-font__color-active: false;
 @icon-font__vertical-align: @icon__vertical-align;
 @icon-font__display: inline-block;
-@icon-font__weight: normal;
+@icon-font__font-weight: normal;
 
 @icon-calendar__font-size: 40px;
 

--- a/lib/web/css/source/lib/variables/_icons.less
+++ b/lib/web/css/source/lib/variables/_icons.less
@@ -32,6 +32,7 @@
 @icon-font__color-active: false;
 @icon-font__vertical-align: @icon__vertical-align;
 @icon-font__display: inline-block;
+@icon-font__weight: normal;
 
 @icon-calendar__font-size: 40px;
 


### PR DESCRIPTION
### Description
Throughout the projects from time to time you need to give a new font weight. The lib-icon-font used to give a normal font-weight hardcoded. Now this is changed with a variable that has the "normal" value as default but can be changed at any moment when you call the function

### Manual testing scenarios
1. Go to any selector that call the .lib-icon-font()
2. Give the variable a new value. For example. `@_icon-font-weight: 500`
3. `setup:di:compile` and `setup:static-content:deploy` will show your changes in the frontend
